### PR TITLE
Check length of string after formatting it

### DIFF
--- a/IRC-Relay/Program.cs
+++ b/IRC-Relay/Program.cs
@@ -100,7 +100,7 @@ namespace IRCRelay
             }
 
             // Send IRC Message
-            if (messageParam.Content.Length > 1000)
+            if (formatted.Length > 1000)
             {
                 await messageParam.Channel.SendMessageAsync("Error: messages > 1000 characters cannot be sent!");
                 return;


### PR DESCRIPTION
If >1000 characters were sent inside a code block, it would not send the message at all rather than just sending hastebin link. This checks the length of string after removing & formatting everything.